### PR TITLE
Fix CTD during launch on Bannerlord version 1.2.9

### DIFF
--- a/Patches/ConversationPatches.cs
+++ b/Patches/ConversationPatches.cs
@@ -1,6 +1,7 @@
 ﻿using HarmonyLib;
 using SandBox.CampaignBehaviors;
 using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.CampaignBehaviors;
 using TaleWorlds.CampaignSystem.ViewModelCollection.Conversation;
 
 namespace Bannerlord.AlwaysShowTitles.Patches


### PR DESCRIPTION
Turns out it just needed to be recompiled, since `LordConversationsCampaignBehavior` is now under `TaleWorlds.CampaignSystem.CampaignBehaviors`. This resolves issue #1.

Testing was limited to launching the game (since the CTD occurred during game loading) and looking at various strings (encyclopedia entries, town descriptions) to see that titles were properly used.